### PR TITLE
feat: background tasks

### DIFF
--- a/backend/fernec/ia_models.py
+++ b/backend/fernec/ia_models.py
@@ -1,0 +1,28 @@
+import os
+
+from tensorflow.keras.models import load_model, Sequential
+from keras.src.saving import serialization_lib
+
+
+def get_cnn_model(path):
+    original_cnn_model = load_model(path)
+    print(f"Loaded CNN model from path {path}")
+    sequential_model = Sequential()
+    for layer in original_cnn_model.layers[:-1]:  # go through until last layer
+        sequential_model.add(layer)
+    return sequential_model
+
+
+def get_rnn_model(path):
+    original_rnn_model = load_model(model_rnn_path)
+    print(f"Loaded RNN model from path {path}")
+    return original_rnn_model
+
+
+# Needed to load model
+serialization_lib.enable_unsafe_deserialization()
+# Load model
+model_cnn_path = os.getenv('MODEL_CNN_PATH', './fernec/ia_models/cotatest.keras')
+model_rnn_path = os.getenv('MODEL_RNN_PATH', './fernec/ia_models/cotatest_rnn_4.keras')
+cnn_model = get_cnn_model(model_cnn_path)
+rnn_model = get_rnn_model(model_rnn_path)

--- a/backend/fernec/predict.py
+++ b/backend/fernec/predict.py
@@ -15,7 +15,7 @@ from fernec.ia_models import cnn_model, rnn_model
 
 router = APIRouter(prefix="/predict")
 
-
+# TODO: this is good enough only for 1 worker
 predictions = {}
 
 @router.post('/image')

--- a/backend/fernec/predict.py
+++ b/backend/fernec/predict.py
@@ -5,22 +5,15 @@ import numpy as np
 
 from PIL import Image
 from starlette.responses import JSONResponse
-from tensorflow.keras.models import load_model
-from keras.src.saving import serialization_lib
 from fastapi import APIRouter, Request, HTTPException
 from fastapi.responses import JSONResponse
 
 from fernec.models import ImageItem, ImagePrediction, VideoPrediction
 from fernec.video_predictor import predict_video, count_frames_per_emotion
+from fernec.ia_models import cnn_model, rnn_model
+
 
 router = APIRouter(prefix="/predict")
-
-# Needed to load model
-serialization_lib.enable_unsafe_deserialization()
-# Load model
-model_cnn_path = os.getenv('MODEL_CNN_PATH', './fernec/ia_models/cotatest.keras')
-model_rnn_path = os.getenv('MODEL_RNN_PATH', './fernec/ia_models/cotatest_rnn_4.keras')
-model = load_model(model_cnn_path)
 
 
 @router.post('/image')
@@ -66,7 +59,7 @@ async def predict_video_endpoint(request: Request) -> VideoPrediction:
         with open(temp_video_path, "wb") as temp_video:
             temp_video.write(contents)
 
-        prediction = predict_video(temp_video_path, model_cnn_path, model_rnn_path)
+        prediction = predict_video(temp_video_path, cnn_model, rnn_model)
 
         result = count_frames_per_emotion(prediction)
         return JSONResponse(status_code=200, content=result)

--- a/backend/fernec/predict.py
+++ b/backend/fernec/predict.py
@@ -1,11 +1,11 @@
-import os
 import io
+import uuid
 import base64
 import numpy as np
 
 from PIL import Image
 from starlette.responses import JSONResponse
-from fastapi import APIRouter, Request, HTTPException
+from fastapi import APIRouter, Request, HTTPException, BackgroundTasks
 from fastapi.responses import JSONResponse
 
 from fernec.models import ImageItem, ImagePrediction, VideoPrediction
@@ -15,6 +15,8 @@ from fernec.ia_models import cnn_model, rnn_model
 
 router = APIRouter(prefix="/predict")
 
+
+predictions = {}
 
 @router.post('/image')
 async def predict_image(image_item: ImageItem) -> ImagePrediction:
@@ -42,8 +44,18 @@ async def predict_image(image_item: ImageItem) -> ImagePrediction:
         raise HTTPException(status_code=400, detail=str(e))
 
 
+@router.get('/{prediction_id}')
+def get_predictions(prediction_id: str) -> JSONResponse:
+    if prediction_id not in predictions.keys():
+        return JSONResponse(content={"message": f"prediction with id {prediction_id} does not exist"}, status_code=404)
+    if predictions[prediction_id] is None:
+        return JSONResponse(content={"message": f"prediction with id {prediction_id} is not ready yet"},
+                            status_code=202)
+    return JSONResponse(content=predictions[prediction_id], status_code=200)
+
+
 @router.post('/video')
-async def predict_video_endpoint(request: Request) -> VideoPrediction:
+async def predict_video_endpoint(request: Request, background_tasks: BackgroundTasks) -> JSONResponse:
     try:
         # Verify there is a file in the request
         form_data = await request.form()
@@ -59,10 +71,18 @@ async def predict_video_endpoint(request: Request) -> VideoPrediction:
         with open(temp_video_path, "wb") as temp_video:
             temp_video.write(contents)
 
-        prediction = predict_video(temp_video_path, cnn_model, rnn_model)
-
-        result = count_frames_per_emotion(prediction)
-        return JSONResponse(status_code=200, content=result)
+        unique_id = str(uuid.uuid4())
+        background_tasks.add_task(predict_video_async, temp_video_path, cnn_model, rnn_model, unique_id)
+        # i.e. prediction is calculating
+        predictions[unique_id] = None
+        return JSONResponse(status_code=202, content={"uuid": unique_id})
         
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+
+def predict_video_async(temp_video_path, cnn_model, rnn_model, unique_id):
+    prediction = predict_video(temp_video_path, cnn_model, rnn_model)
+    result = count_frames_per_emotion(prediction)
+    predictions[unique_id] = result
+    print(f"prediction is done for unique_id {unique_id}")

--- a/backend/fernec/video_predictor.py
+++ b/backend/fernec/video_predictor.py
@@ -27,13 +27,7 @@ FRAMES_ORDER_MAGNITUDE = 5
 FACE_BATCH_SIZE = 20
 
 
-def prepare_frames(model_cnn_path, verbose=False):
-    cnn_model = load_model(model_cnn_path)
-    
-    model = Sequential()
-    for layer in cnn_model.layers[:-1]: # go through until last layer
-        model.add(layer)
-
+def prepare_frames(cnn_model, verbose=False):
     files = os.listdir(TMP_FRAMES_READY_PATH)
     iterations = math.ceil(len(files) / MAX_SEQ_LENGTH)
 
@@ -55,7 +49,7 @@ def prepare_frames(model_cnn_path, verbose=False):
                 img = np.reshape(frame, (HEIGHT, WIDTH, CHANNELS))
                 img = np.expand_dims(img, axis=0)
         
-                prediction = model.predict(img, verbose=0) # shape (1, num_features)
+                prediction = cnn_model.predict(img, verbose=0) # shape (1, num_features)
                 assert len(prediction[0]) == NUM_FEATURES, 'Error features'
         
                 frames_features[iteration, idx] = prediction[0]
@@ -71,7 +65,7 @@ def prepare_frames(model_cnn_path, verbose=False):
     return [frames_features, frames_mask]
 
 
-def predict_video(video_path, model_cnn_path, model_rnn_path):
+def predict_video(video_path, cnn_model, rnn_model):
 
     create_folder_if_not_exists(TMP_FRAMES_READY_PATH)
     clean_folder(TMP_FRAMES_READY_PATH)
@@ -86,11 +80,8 @@ def predict_video(video_path, model_cnn_path, model_rnn_path):
             faces_only=True
     )
 
-    model_imported = load_model(model_rnn_path)
-    print("Loaded model from path " + model_rnn_path)
-
-    frames_to_predict = prepare_frames(model_cnn_path)
-    predictions = model_imported.predict(frames_to_predict)
+    frames_to_predict = prepare_frames(cnn_model)
+    predictions = rnn_model.predict(frames_to_predict)
 
     return predictions
 


### PR DESCRIPTION
- transforma la lógica del servicio `/predict/video` en una tarea de ejecución async
- expone un servicio `/predict/:prediction_id`
- se levantan cnn y rnn al inicializar el worker