### PR TITLE
feat: send email with predictions

### DIFF
--- a/backend/config_example.yaml
+++ b/backend/config_example.yaml
@@ -2,7 +2,7 @@ host: 0.0.0.0
 port: 8000
 cnn_path: "./cotatest.keras"
 rnn_path: "./cotatest_rnn_4.keras"
-cnn_path: "./vgg16_eche_4.keras"
+cnn_binary_path: "./vgg16_eche_4.keras"
 rnn_binary_path: "./eche_rnn_binary_3.keras"
 video_config:
   HEIGHT: 112
@@ -12,3 +12,8 @@ video_config:
   NUM_FEATURES: 1024
   FRAMES_ORDER_MAGNITUDE: 5
   FACE_BATCH_SIZE: 20
+email_config:
+  EMAIL_SENDER: "fernec.fiuba@gmail.com"
+  EMAIL_PASSWORD: "fake_password"
+  SMTP_HOST: "smtp.gmail.com"
+  SMTP_PORT: 465

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -9,7 +9,8 @@ from ipaddress import IPv4Address, IPv6Address
 
 from routers.predict import router as predict_router
 from routers.health import router as state_router
-from routers.video_predictor import VideoConfig
+from routers.messaging import router as messaging_router
+from routers.models import VideoConfig, EmailConfig
 
 # Needed to load models
 serialization_lib.enable_unsafe_deserialization()
@@ -23,6 +24,7 @@ class AppConfig(BaseModel):
     cnn_binary_path: str
     rnn_binary_path: str
     video_config: VideoConfig
+    email_config: EmailConfig
 
 
 def parse_config(path: str) -> AppConfig:
@@ -45,7 +47,6 @@ def gen_init(cfg: AppConfig):
         print('Feature extractor loaded... OK')
         # Load RNN
         app.state.rnn_model = load_model(cfg.rnn_path)
-        app.state.video_config = cfg.video_config
         print('RNN loaded... OK')
 
         # Binary
@@ -60,6 +61,9 @@ def gen_init(cfg: AppConfig):
 
         app.state.rnn_binary_model = load_model(cfg.rnn_binary_path)
         print('RNN Binary loaded... OK')
+
+        app.state.video_config = cfg.video_config
+        app.state.email_config = cfg.email_config
 
         yield
         del app.state.cnn_model
@@ -84,4 +88,5 @@ def get_application(cfg: AppConfig) -> FastAPI:
     # Add routers
     application.include_router(predict_router)
     application.include_router(state_router)
+    application.include_router(messaging_router)
     return application

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -7,9 +7,7 @@ from keras.src.saving import serialization_lib
 from pydantic import BaseModel
 from ipaddress import IPv4Address, IPv6Address
 
-from routers.predict import router as predict_router
-from routers.health import router as state_router
-from routers.messaging import router as messaging_router
+from routers.main import v1_router
 from routers.models import VideoConfig, EmailConfig
 
 # Needed to load models
@@ -86,7 +84,5 @@ def get_application(cfg: AppConfig) -> FastAPI:
     )
 
     # Add routers
-    application.include_router(predict_router)
-    application.include_router(state_router)
-    application.include_router(messaging_router)
+    application.include_router(v1_router)
     return application

--- a/backend/routers/main.py
+++ b/backend/routers/main.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+
+from .health import router as health_router
+from .predict import router as predict_router
+from .messaging import router as messaging_router
+
+v1_router = APIRouter(prefix="/v1")
+v1_router.include_router(predict_router)
+v1_router.include_router(health_router)
+v1_router.include_router(messaging_router)

--- a/backend/routers/messaging.py
+++ b/backend/routers/messaging.py
@@ -1,0 +1,39 @@
+import smtplib
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+from http.client import responses
+from fastapi import APIRouter, Request, HTTPException, BackgroundTasks
+from fastapi.responses import JSONResponse
+from fastapi.encoders import jsonable_encoder
+
+from .models import Email, EmailConfig
+
+router = APIRouter(prefix="/messaging")
+
+
+@router.post('/email')
+async def send_email(request: Request, email: Email) -> JSONResponse:
+    try:
+        _send_email(email.recipients, email.subject, email.body, request.app.state.email_config)
+        return JSONResponse(status_code=201, content=jsonable_encoder(email))
+    except Exception as e:
+        print(f"Exception sending email. Error detail: {e}")
+        raise HTTPException(status_code=500, detail=responses[500])
+
+
+def _send_email(recipients: list[str], subject: str, body: str, email_config: EmailConfig) -> None:
+    sender = email_config.EMAIL_SENDER
+    password = email_config.EMAIL_PASSWORD
+    smtp_host = email_config.SMTP_HOST
+    smtp_port = email_config.SMTP_PORT
+
+    msg = MIMEMultipart('alternative')
+    msg['Subject'] = subject
+    msg['From'] = sender
+    msg['To'] = ', '.join(recipients)
+    html_body = MIMEText(body, 'html')
+    msg.attach(html_body)
+    with smtplib.SMTP_SSL(smtp_host, smtp_port) as smtp_server:
+        smtp_server.login(sender, password)
+        smtp_server.sendmail(sender, recipients, msg.as_string())
+    print("Message sent!")

--- a/backend/routers/messaging.py
+++ b/backend/routers/messaging.py
@@ -33,6 +33,7 @@ def _send_email(recipients: list[str], subject: str, body: str, email_config: Em
     msg['To'] = ', '.join(recipients)
     html_body = MIMEText(body, 'html')
     msg.attach(html_body)
+
     with smtplib.SMTP_SSL(smtp_host, smtp_port) as smtp_server:
         smtp_server.login(sender, password)
         smtp_server.sendmail(sender, recipients, msg.as_string())

--- a/backend/routers/models.py
+++ b/backend/routers/models.py
@@ -22,3 +22,26 @@ class ImagePrediction(BaseModel):
 
 class VideoPrediction(BaseModel):
     prediction: list[str]
+
+
+class VideoConfig(BaseModel):
+    MAX_SEQ_LENGTH: int
+    FRAMES_ORDER_MAGNITUDE: int
+    HEIGHT: int
+    WIDTH: int
+    CHANNELS: int = 3
+    NUM_FEATURES: int
+    FACE_BATCH_SIZE: int
+
+
+class EmailConfig(BaseModel):
+    EMAIL_SENDER: str
+    EMAIL_PASSWORD: str
+    SMTP_HOST: str
+    SMTP_PORT: int
+
+
+class Email(BaseModel):
+    recipients: list[str]
+    subject: str
+    body: str

--- a/backend/routers/predict.py
+++ b/backend/routers/predict.py
@@ -103,6 +103,6 @@ def send_email_with_prediction_results(unique_id, request: Request):
     email_config = request.app.state.email_config
     print("about to send prediction results!")
     recipients = ["fernec.fiuba@gmail.com"]
-    url = f"http://localhost:8000/predict/{unique_id}"
+    url = f"http://localhost:8000/v1/predict/{unique_id}"
     body = f"<html><body>Hello. <a href='{url}'>Click here</a> to see your result!</body>"
     _send_email(recipients, "fernec results", body, email_config)

--- a/backend/routers/predict.py
+++ b/backend/routers/predict.py
@@ -8,8 +8,9 @@ from PIL import Image
 from fastapi import APIRouter, Request, HTTPException, BackgroundTasks
 from fastapi.responses import JSONResponse
 
-from .models import ImageItem, ImagePrediction, VideoPrediction
+from .models import ImageItem, ImagePrediction, VideoPrediction, EmailConfig
 from .video_predictor import predict_video, count_frames_per_emotion
+from .messaging import _send_email
 
 
 router = APIRouter(prefix="/predict")
@@ -74,12 +75,8 @@ async def predict_video_endpoint(request: Request, background_tasks: BackgroundT
             temp_video.write(contents)
 
         unique_id = str(uuid.uuid4())
-        feature_extractor = request.app.state.feature_extractor
-        rnn =  request.app.state.rnn_model
-        feature_extractor_binary = request.app.state.feature_binary_extractor
-        rnn_binary = request.app.state.rnn_binary_model
-        cfg = request.app.state.video_config
-        background_tasks.add_task(predict_video_async, temp_video_path, feature_extractor, rnn, feature_extractor_binary, rnn_binary, unique_id, cfg)
+        background_tasks.add_task(predict_video_async, temp_video_path, unique_id, request,
+                                  background_tasks)
         # i.e. prediction is calculating
         predictions[unique_id] = None
         return JSONResponse(status_code=202, content={"uuid": unique_id})
@@ -88,8 +85,25 @@ async def predict_video_endpoint(request: Request, background_tasks: BackgroundT
         raise HTTPException(status_code=500, detail=str(e))
 
 
-def predict_video_async(temp_video_path, cnn_model, rnn_model, cnn_binary_model, rnn_binary_model, unique_id, video_config):
-    prediction, prediction_binary = predict_video(temp_video_path, cnn_model, rnn_model, cnn_binary_model, rnn_binary_model, video_config)
+def predict_video_async(temp_video_path: str, unique_id: str, request: Request, background_tasks: BackgroundTasks):
+    feature_extractor = request.app.state.feature_extractor
+    rnn_model = request.app.state.rnn_model
+    feature_extractor_binary = request.app.state.feature_binary_extractor
+    rnn_binary_model = request.app.state.rnn_binary_model
+    video_config = request.app.state.video_config
+
+    prediction, prediction_binary = predict_video(temp_video_path, feature_extractor, rnn_model,
+                                                  feature_extractor_binary, rnn_binary_model, video_config)
     result = count_frames_per_emotion(prediction, prediction_binary)
     predictions[unique_id] = result
     print(f"prediction is done for unique_id {unique_id}")
+    background_tasks.add_task(send_email_with_prediction_results, unique_id, request)
+
+
+def send_email_with_prediction_results(unique_id, request: Request):
+    email_config = request.app.state.email_config
+    print("about to send prediction results!")
+    recipients = ["fernec.fiuba@gmail.com"]
+    url = f"http://localhost:8000/predict/{unique_id}"
+    body = f"<html><body>Hello. <a href='{url}'>Click here</a> to see your result!</body>"
+    _send_email(recipients, "fernec results", body, email_config)

--- a/backend/routers/predict.py
+++ b/backend/routers/predict.py
@@ -8,10 +8,9 @@ from PIL import Image
 from fastapi import APIRouter, Request, HTTPException, BackgroundTasks
 from fastapi.responses import JSONResponse
 
-from .models import ImageItem, ImagePrediction, VideoPrediction, EmailConfig
+from .models import ImageItem
 from .video_predictor import predict_video, count_frames_per_emotion
 from .messaging import _send_email
-
 
 router = APIRouter(prefix="/predict")
 

--- a/backend/routers/video_predictor.py
+++ b/backend/routers/video_predictor.py
@@ -5,22 +5,12 @@ import numpy as np
 
 from preprocessing.frames_generator.strategy.videos_processor.videos import get_frames_from_video
 from preprocessing.frames_generator.utils import create_folder_if_not_exists, clean_folder
-from pydantic import BaseModel
+from .models import VideoConfig
 
 # Temp path to save the frames extracted from the video
 TMP_FRAMES_PATH = "./temp/frames/"
 # In this path we will save the frames that are ready to be predicted
 TMP_FRAMES_READY_PATH = "temp/frames_ready/"
-
-
-class VideoConfig(BaseModel):
-    MAX_SEQ_LENGTH: int
-    FRAMES_ORDER_MAGNITUDE: int
-    HEIGHT: int
-    WIDTH: int
-    CHANNELS: int = 3
-    NUM_FEATURES: int
-    FACE_BATCH_SIZE: int
 
 
 def prepare_frames(feature_extractor, cfg: VideoConfig, verbose=False):


### PR DESCRIPTION
- :warning: se agrega un `/v1` a todos los servicios :smiley_cat: 
- se expone un servicio para enviar emails
- se agrega como background task el envio de un email con los resultados (por ahora todos los mails se envian desde y hacia  `fernec.fiuba@gmail.com`
- moví el `VideoConfig` a los models
- algunos cambios en la predicción: ahora las background tasks reciben la request como parámetro para obtener del contexto de la app lo que cada task necesita (esto podemos discutirlo si quieren, yo lo cambié porque me pareció mejor que mandar muchos parámetros y además cada task se encarga de obtener la info que ella misma necesita)