### PR TITLE
Fix percentage in donut chart

### DIFF
--- a/web/src/app/results/[data]/DonutChartBinary.tsx
+++ b/web/src/app/results/[data]/DonutChartBinary.tsx
@@ -7,9 +7,9 @@ export const DonutChartBinary = ({ results }: { results: EmotionResults }) => {
   const data = results.emotions_binary.map((emotion) => ({
     name: emotion.label,
     amount: emotion.total_seconds,
-    share: `${Math.round(
+    share: `${(
       (emotion.total_seconds / results.total_seconds) * 100
-    )}%`,
+    ).toFixed(1)}%`,
     color: emotion.label === "Negative" ? "bg-red-500" : "bg-green-500",
   }));
   return (


### PR DESCRIPTION
En el piechart de las emociones negativas en algunos casos los porcentajes daban más de 100% por un tema de redondeo.
Por ejemplo:
![image](https://github.com/user-attachments/assets/28a5f9a6-e450-4547-a92b-f5cdb1c2cf81)

Se quitó el Math.Round y se muestra siempre un decimal para así poder dar un resultado más certero y no pasarse de 100%:
![image](https://github.com/user-attachments/assets/611baf1b-0642-4ab7-9645-0ff7efec7473)
